### PR TITLE
Fixing Extract.autodesk.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ http://developer-autodesk.github.io/translated-models/dwfx-sample-house/f0224dd3
 
 You can also download those translated models from this [GitHub repo](https://github.com/Developer-Autodesk/translated-models).
 
-You can translate your own models at [extract.autodesk.io](extract.autodesk.io).
+You can translate your own models at [extract.autodesk.io](http://extract.autodesk.io).
 
 ## Written By
 Shiya Luo


### PR DESCRIPTION
Hi Shiya, 

The link in the Readme file is pointing to https://github.com/Developer-Autodesk/view-and-data-offline-sample/blob/gh-pages/extract.autodesk.io which gives you a 404 error. 

I added http:// to the beginning of the link and that did the fix. 

Cheers,
J
